### PR TITLE
SelectedCities is visible when empty and automatically populates on reload

### DIFF
--- a/src/__mocks__/axios.js
+++ b/src/__mocks__/axios.js
@@ -1,5 +1,6 @@
 // A list of dummy data to get the search form functional
 // Data pulled from: https://simple.wikipedia.org/wiki/List_of_United_States_cities_by_population#Cities_that_used_to_have_100,000_people
+import axios from "axios";
 const cities = [
   { id: 1, name: "Albany", state: "NY" },
   { id: 2, name: "Allegheny", state: "PA" },
@@ -38,7 +39,8 @@ export default {
       case "https://b-ds.citrics.dev/cities":
         return Promise.resolve({ data: { cities } });
       default:
-        throw new Error(`UNMATCHED URL: ${url}`);
+        console.warn(`Warning: axios request was not mocked: ${url}`);
+        return axios.get(url);
     }
   })
 };

--- a/src/__tests__/NavContainer.test.js
+++ b/src/__tests__/NavContainer.test.js
@@ -1,6 +1,7 @@
 import Nav from "../components/pages/Nav/NavContainer";
 import React from "react";
 import ReactDOM from "react-dom";
+import { BrowserRouter as Router } from "react-router-dom";
 import { Provider } from "react-redux";
 import { render, fireEvent } from "@testing-library/react";
 import configureStore from "redux-mock-store";
@@ -17,9 +18,11 @@ describe("<NavContainer />", () => {
       });
       store.dispatch = jest.fn();
       component = render(
-        <Provider store={store}>
-          <Nav />
-        </Provider>
+        <Router>
+          <Provider store={store}>
+            <Nav />
+          </Provider>
+        </Router>
       );
     });
 
@@ -62,9 +65,11 @@ describe("<NavContainer />", () => {
       });
       store.dispatch = jest.fn();
       component = render(
-        <Provider store={store}>
-          <Nav />
-        </Provider>
+        <Router>
+          <Provider store={store}>
+            <Nav />
+          </Provider>
+        </Router>
       );
     });
 

--- a/src/__tests__/SelectedCities.test.js
+++ b/src/__tests__/SelectedCities.test.js
@@ -28,14 +28,19 @@ describe("<NavContainer />", () => {
       );
       ReactDOM.unmountComponentAtNode(div);
     });
-    it("Is hidden when no cities are selected", () => {
-      const { queryByText } = render(
+    it("Displays a message and disabled button when no city is selected", async done => {
+      const { findByText } = render(
         <Provider store={store}>
           <SelectedCities />
         </Provider>
       );
-      const header = queryByText(/selected cities/i);
-      expect(header).toBeNull();
+      // The message should say "No city selected"
+      await findByText(/no city selected/i);
+      // The ant button is the parent element of the span with "Details" in it
+      // It should be disabled
+      const button = await findByText(/details/i);
+      expect(button.parentElement.getAttribute("disabled")).toEqual("");
+      done();
     });
   });
   describe("Tests with one city selected", () => {

--- a/src/components/pages/CityPage/CityPage.js
+++ b/src/components/pages/CityPage/CityPage.js
@@ -12,7 +12,7 @@ class CityPage extends React.Component {
     // If we don't have cached data on this city, retrieve it
     if (!this.props.cityDetails[id]) {
       // We need to wait for getCityDetails to finish before proceeding
-      await this.props.getCityDetails({ id, name: "Testing" });
+      await this.props.getCityDetails({ id });
     }
     this.setState({ city: this.props.cityDetails[id] });
   };

--- a/src/components/pages/Comparison/ComparisonContainer.js
+++ b/src/components/pages/Comparison/ComparisonContainer.js
@@ -46,7 +46,7 @@ class ComparisonContainer extends React.Component {
     for (const id of selectedCities) {
       if (!this.props.cityDetails[id]) {
         // Make sure each server request finished before proceeding
-        await this.props.getCityDetails({ id, name: "Testing" });
+        await this.props.getCityDetails({ id });
       }
     }
     // Get citiesData using the latest information from Redux passed thru props

--- a/src/components/pages/Nav/SelectedCities.js
+++ b/src/components/pages/Nav/SelectedCities.js
@@ -30,18 +30,20 @@ function SelectedCities({ selectedCities, removeCity, cityDetails }) {
     return str;
   };
   // Hide the component if there are no cities to show
-  return selectedCities.length === 0 ? (
-    <div />
-  ) : (
+  return (
     <>
       {/* TODO: Replace this with Ant Design components */}
       <h4>Selected Cities</h4>
-      {selectedCities.map(({ name, state, id }) => (
-        <div key={id} data-id={id} onClick={removeFromSelectedCities}>
-          {`${name}, ${state} `}
-          &nbsp; <CloseCircleFilled className="remove-city" />
-        </div>
-      ))}
+      {selectedCities.length === 0 ? (
+        <div>No city selected</div>
+      ) : (
+        selectedCities.map(({ name, state, id }) => (
+          <div key={id} data-id={id} onClick={removeFromSelectedCities}>
+            {`${name}, ${state} `}
+            &nbsp; <CloseCircleFilled className="remove-city" />
+          </div>
+        ))
+      )}
 
       {/* Dynamic Button that responds to how many cities are selected */}
       <div className="btn-container">
@@ -57,6 +59,7 @@ function SelectedCities({ selectedCities, removeCity, cityDetails }) {
         ) : (
           <Button
             type="primary"
+            disabled={selectedCities.length === 0}
             onClick={() =>
               history.push(`/city-detail-page/${selectedCities[0].id}`)
             }

--- a/src/state/actions/cityActions.js
+++ b/src/state/actions/cityActions.js
@@ -21,7 +21,7 @@ export const getCityDetails = ({ id, name, state }) => {
     population: 100,
     weather: "perfect",
     rent: 10000,
-    name,
+    name: name ?? "Example City",
     state: state ?? "CA"
   };
   return {


### PR DESCRIPTION
# Description
SelectedCities now renders a placeholder instead of being blank when no city is selected.
If you load a comparison page or detail page directly, SearchBar will detect which cities you're viewing and save their information in Redux. Then SelectedCities will render them just as though you'd manually added them yourself.
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Change Status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback
## Has This Been Tested
- [x] Yes
- [ ] No
- [ ] Not necessary
## Does this require communication between DS and WEB?
- [ ] Yes, and I have already reached out to someone
- [ ] Yes, but I still need to reach out to someone
- [x] No
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least two peers
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
